### PR TITLE
Add action for publishing backstage plugins

### DIFF
--- a/publish-backstage-plugins/README.md
+++ b/publish-backstage-plugins/README.md
@@ -1,0 +1,294 @@
+# Publish Backstage Plugins
+
+This GitHub composite action discovers Backstage plugins in the local `plugins/` directory, builds them, assigns a release version, packs them, and publishes them to the GitHub npm registry.
+
+It is intended for monorepos that contain one or more Backstage plugins under `plugins/<plugin-name>`.
+
+## Important versioning note
+
+**The published package version is derived from the root `package.json`, not from each plugin's own `package.json`.**
+
+The action reads the version from the repository root `package.json`, removes any existing prerelease suffix, and then generates the final published version based on the branch and commit SHA. That generated version is then written into each plugin package before packing and publishing.
+
+## What it does
+
+The action performs the following steps:
+
+1. Checks out the repository with full history
+2. Sets up Node.js 22
+3. Enables Yarn 4.4.1 through Corepack
+4. Installs dependencies using `yarn install --immutable`
+5. Generates TypeScript declaration files with `yarn tsc`
+6. Determines a release version from the **root `package.json` version**
+7. Discovers plugin packages under `plugins/`
+8. Builds each plugin with `yarn build`
+9. Updates each plugin's `package.json` version to the generated release version and removes the `private` flag
+10. Performs a preflight check to ensure the target package versions do not already exist
+11. Packs each plugin into an npm tarball
+12. Publishes each tarball to the GitHub npm registry
+13. Writes action outputs for downstream workflow steps
+14. Writes a summary to the GitHub Actions job summary
+
+## Requirements
+
+This action assumes:
+
+- Your repository uses Yarn
+- Your repository contains Backstage plugins under `plugins/`
+- Each plugin directory contains a valid `package.json`
+- Each plugin can be built by running `yarn build` inside its own directory
+- The **root `package.json` contains the version that will be used as the basis for all published plugin versions**
+- Packages are published to the GitHub Packages npm registry
+- Package names use the `@bcgov` scope
+
+## Inputs
+
+### `token`
+
+GitHub token used to authenticate against GitHub Packages.
+
+Required: `true`
+
+This token must have permission to publish packages.
+
+## Outputs
+
+This action exposes the following outputs for use in later workflow steps.
+
+### `version`
+
+The generated release version derived from the root `package.json`.
+
+Example:
+
+```yaml
+${{ steps.publish_plugins.outputs.version }}
+```
+
+### `published_package_versions`
+
+A JSON array describing the packages that were published.
+
+Example shape:
+
+```json
+[
+  {
+    "name": "@bcgov/plugin-a",
+    "version": "1.2.4-main.abcdef12",
+    "path": "plugins/plugin-a"
+  },
+  {
+    "name": "@bcgov/plugin-b",
+    "version": "1.2.4-main.abcdef12",
+    "path": "plugins/plugin-b"
+  }
+]
+```
+
+### `plugin_count`
+
+The number of plugins published.
+
+Example:
+
+```yaml
+${{ steps.publish_plugins.outputs.plugin_count }}
+```
+
+## Versioning strategy
+
+**All published plugin versions are based on the version in the root `package.json`.**
+
+The action calculates the publish version from the root `package.json` version and the current Git ref.
+
+### How the base version is determined
+
+The action runs this logic against the repository root:
+
+```bash
+ROOT_VERSION="$(node -p "require('./package.json').version")"
+BASE_VERSION="$(echo "$ROOT_VERSION" | sed 's/-.*//')"
+```
+
+That means:
+
+- It reads `version` from the root `package.json`
+- It strips any existing prerelease suffix
+- It uses that stripped value as the base for all published plugin versions
+
+Example:
+
+- Root version: `1.2.3`
+- Base version used for publishing: `1.2.3`
+
+Example with prerelease input:
+
+- Root version: `1.2.3-beta.1`
+- Base version used for publishing: `1.2.3`
+
+### Main branch
+
+If the workflow runs on `refs/heads/main`, the action:
+
+- Reads the version from the **root `package.json`**
+- Removes any prerelease suffix
+- Increments the patch number by 1
+- Appends `-main.<sha8>`
+
+Example:
+
+- Root version: `1.2.3`
+- Commit SHA: `abcdef123456...`
+- Published version: `1.2.4-main.abcdef12`
+
+### Other branches
+
+If the workflow runs on any non-main branch, the action:
+
+- Reads the version from the **root `package.json`**
+- Removes any prerelease suffix
+- Normalizes the branch name
+- Appends `-feature.<branch-name>.<sha8>`
+
+Example:
+
+- Root version: `1.2.3`
+- Branch: `feature/my-new-plugin`
+- Commit SHA: `abcdef123456...`
+- Published version: `1.2.3-feature.my-new-plugin.abcdef12`
+
+## Plugin discovery
+
+The action searches for plugin directories using:
+
+```bash
+find plugins -mindepth 1 -maxdepth 1 -type d -exec test -f '{}/package.json' ';' -print
+```
+
+Only direct subdirectories of `plugins/` that contain a `package.json` are included.
+
+## Publish flow
+
+For each discovered plugin, the action:
+
+- Runs `yarn build`
+- Sets the plugin `package.json.version` to the generated release version
+- Removes `private` from the plugin `package.json`
+- Creates an npm tarball using `npm pack`
+- Publishes the tarball with `npm publish`
+
+Before publishing, it checks whether that exact package version already exists in GitHub Packages. If any package version already exists, the action fails before publishing anything.
+
+## Example usage
+
+```yaml
+name: Publish Plugins
+
+on:
+  push:
+    branches:
+      - main
+      - 'feature/**'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Publish Backstage plugins
+        id: publish_plugins
+        uses: ./.github/actions/publish-backstage-plugins
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Show publish outputs
+        shell: bash
+        run: |
+          echo "Version: ${{ steps.publish_plugins.outputs.version }}"
+          echo "Plugin count: ${{ steps.publish_plugins.outputs.plugin_count }}"
+          echo 'Published packages: ${{ steps.publish_plugins.outputs.published_package_versions }}'
+```
+
+## Registry configuration
+
+The action publishes to:
+
+```text
+https://npm.pkg.github.com
+```
+
+It configures the npm scope as:
+
+```text
+@bcgov
+```
+
+Make sure your package names match that scope if you want them published successfully.
+
+Example:
+
+```json
+{
+  "name": "@bcgov/my-backstage-plugin"
+}
+```
+
+## GitHub Actions summary
+
+The action writes a summary to the workflow run that includes:
+
+- Calculated release version
+- Git ref and commit SHA
+- Planned packages
+- Published packages
+- Example install commands
+
+## Failure conditions
+
+The action will fail if:
+
+- No plugins are found under `plugins/`
+- Dependency installation fails
+- TypeScript declaration generation fails
+- Any plugin build fails
+- A target package version already exists in the registry
+- A tarball is not created as expected
+- Publishing any package fails
+
+## Notes
+
+- The published package version is based on the **root `package.json` version**
+- The action mutates each plugin's `package.json` during the workflow by changing the version and removing `private`
+- Those changes occur only in the workflow workspace and are not committed back to the repository
+- Temporary working files are written under `/tmp`
+- The `published_package_versions` output is JSON, so downstream steps may want to parse it before using individual fields
+
+## Expected repository structure
+
+```text
+.
+├── package.json
+├── plugins
+│   ├── plugin-a
+│   │   ├── package.json
+│   │   └── ...
+│   └── plugin-b
+│       ├── package.json
+│       └── ...
+└── .github
+    └── actions
+        └── publish-backstage-plugins
+            └── action.yml
+```
+
+## Tips
+
+- Keep the **root `package.json` version** up to date, since all published plugin versions are derived from it
+- Ensure each plugin has a working `build` script
+- Use branch names that normalize cleanly into prerelease identifiers
+- Grant `packages: write` permission to the workflow job

--- a/publish-backstage-plugins/action.yaml
+++ b/publish-backstage-plugins/action.yaml
@@ -5,8 +5,15 @@ inputs:
     description: "GitHub token for authentication"
     required: true
 outputs:
-  result:
-    description: "Summary of actions taken"
+  version:
+    description: "The generated release version derived from the root package.json"
+    value: ${{ steps.finalize.outputs.version }}
+  published_package_versions:
+    description: "JSON array of published package names and versions"
+    value: ${{ steps.finalize.outputs.published_package_versions }}
+  plugin_count:
+    description: "Number of plugins published"
+    value: ${{ steps.finalize.outputs.plugin_count }}
 runs:
   using: "composite"
   steps:
@@ -217,6 +224,33 @@ runs:
           echo "Publishing $package_name@$package_version"
           npm publish "$tarball_path" --registry=https://npm.pkg.github.com
         done < /tmp/publish-tarballs.txt
+
+    - name: Finalize outputs
+      id: finalize
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        echo "version=${{ steps.version.outputs.version }}" >> "$GITHUB_OUTPUT"
+        echo "plugin_count=$(wc -l < /tmp/publish-tarballs.txt | tr -d '[:space:]')" >> "$GITHUB_OUTPUT"
+
+        published_package_versions="$(
+          node -e "
+            const fs = require('fs');
+            const lines = fs.readFileSync('/tmp/publish-tarballs.txt', 'utf8')
+              .split('\n')
+              .filter(Boolean);
+
+            const packages = lines.map(line => {
+              const [pluginPath, packageName, packageVersion] = line.split('|');
+              return { name: packageName, version: packageVersion, path: pluginPath };
+            });
+
+            process.stdout.write(JSON.stringify(packages));
+          "
+        )"
+
+        echo "published_package_versions=${published_package_versions}" >> "$GITHUB_OUTPUT"
 
     - name: Write published summary
       if: ${{ success() }}

--- a/publish-backstage-plugins/action.yaml
+++ b/publish-backstage-plugins/action.yaml
@@ -1,0 +1,244 @@
+name: "Publish Backstage Plugins"
+description: "Publishes Backstage plugins to the npm registry."
+inputs:
+  token:
+    description: "GitHub token for authentication"
+    required: true
+outputs:
+  result:
+    description: "Summary of actions taken"
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: "22"
+        registry-url: "https://npm.pkg.github.com"
+        scope: "@bcgov"
+
+    - name: Setup Yarn
+      run: corepack enable && corepack prepare yarn@4.4.1 --activate
+
+    - name: Install dependencies
+      run: yarn install --immutable
+
+    - name: Generate TypeScript declaration files
+      run: yarn tsc
+
+    - name: Determine release version
+      id: version
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        ROOT_VERSION="$(node -p "require('./package.json').version")"
+        BASE_VERSION="$(echo "$ROOT_VERSION" | sed 's/-.*//')"
+        SHA8="${GITHUB_SHA::8}"
+
+        if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+          IFS='.' read -ra VERSION_PARTS <<< "$BASE_VERSION"
+          MAJOR="${VERSION_PARTS[0]}"
+          MINOR="${VERSION_PARTS[1]}"
+          PATCH="${VERSION_PARTS[2]}"
+          NEW_PATCH=$((PATCH + 1))
+          NEW_VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}-main.${SHA8}"
+        else
+          BRANCH_NAME="$(echo "${GITHUB_REF_NAME}" \
+            | sed 's/^feature\///' \
+            | sed 's/[^a-zA-Z0-9-]/-/g' \
+            | tr '[:upper:]' '[:lower:]')"
+          BRANCH_NAME="$(echo "$BRANCH_NAME" \
+            | sed 's/^-*//' \
+            | sed 's/-*$//' \
+            | sed 's/-\+/-/g')"
+          NEW_VERSION="${BASE_VERSION}-feature.${BRANCH_NAME}.${SHA8}"
+        fi
+
+        echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+        echo "Release version: ${NEW_VERSION}"
+
+    - name: Discover plugins
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        find plugins -mindepth 1 -maxdepth 1 -type d \
+          -exec test -f '{}/package.json' ';' -print \
+          | sort > /tmp/plugin-paths.txt
+
+        if [ ! -s /tmp/plugin-paths.txt ]; then
+          echo "No plugins found under plugins/"
+          exit 1
+        fi
+
+        echo "Discovered plugins:"
+        while IFS= read -r plugin_path; do
+          package_name="$(node -p "require('./${plugin_path}/package.json').name")"
+          echo "Found plugin: ${package_name} (${plugin_path})"
+        done < /tmp/plugin-paths.txt
+
+    - name: Prepare plugins and create publish plan
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        mkdir -p /tmp/plugin-tarballs
+        : > /tmp/publish-plan.txt
+
+        RELEASE_VERSION="${{ steps.version.outputs.version }}"
+
+        while IFS= read -r plugin_path; do
+          echo ""
+          echo "Preparing $plugin_path"
+
+          package_name="$(node -p "require('./${plugin_path}/package.json').name")"
+
+          echo "Building $plugin_path"
+          (
+            cd "$plugin_path"
+            yarn build
+          )
+
+          echo "Updating package.json for $plugin_path"
+          (
+            cd "$plugin_path"
+            npm pkg set version="$RELEASE_VERSION"
+            npm pkg delete private
+          )
+
+          echo "$plugin_path|$package_name|$RELEASE_VERSION" >> /tmp/publish-plan.txt
+        done < /tmp/plugin-paths.txt
+
+        echo ""
+        echo "Publish plan:"
+        while IFS='|' read -r plugin_path package_name package_version; do
+          echo "Planned: ${package_name}@${package_version} (${plugin_path})"
+        done < /tmp/publish-plan.txt
+
+    - name: Write release summary
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        {
+          echo "## Plugin publish summary"
+          echo ""
+          echo "- Release version: \`${{ steps.version.outputs.version }}\`"
+          echo "- Git ref: \`${GITHUB_REF}\`"
+          echo "- Commit: \`${GITHUB_SHA}\`"
+          echo ""
+          echo "### Planned packages"
+          echo ""
+          echo "| Package | Version | Path |"
+          echo "|---|---|---|"
+          while IFS='|' read -r plugin_path package_name package_version; do
+            echo "| \`${package_name}\` | \`${package_version}\` | \`${plugin_path}\` |"
+          done < /tmp/publish-plan.txt
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Preflight check package versions
+      shell: bash
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.token }}
+      run: |
+        set -euo pipefail
+
+        any_conflicts=0
+
+        while IFS='|' read -r plugin_path package_name package_version; do
+          echo ""
+          echo "Checking $package_name@$package_version"
+
+          if npm view "${package_name}@${package_version}" version \
+            --registry=https://npm.pkg.github.com >/dev/null 2>&1; then
+            echo "ERROR: ${package_name}@${package_version} already exists"
+            any_conflicts=1
+          else
+            echo "OK: ${package_name}@${package_version} does not exist yet"
+          fi
+        done < /tmp/publish-plan.txt
+
+        if [ "$any_conflicts" -ne 0 ]; then
+          echo ""
+          echo "Preflight failed because one or more package versions already exist."
+          exit 1
+        fi
+
+    - name: Pack all plugins
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        : > /tmp/publish-tarballs.txt
+
+        while IFS='|' read -r plugin_path package_name package_version; do
+          echo ""
+          echo "Packing $package_name@$package_version from $plugin_path"
+
+          tarball_name="$(
+            cd "$plugin_path"
+            npm pack --pack-destination /tmp/plugin-tarballs | tail -n 1
+          )"
+
+          tarball_path="/tmp/plugin-tarballs/$tarball_name"
+
+          if [ ! -f "$tarball_path" ]; then
+            echo "ERROR: Expected tarball not found: $tarball_path"
+            exit 1
+          fi
+
+          echo "$plugin_path|$package_name|$package_version|$tarball_path" >> /tmp/publish-tarballs.txt
+        done < /tmp/publish-plan.txt
+
+        echo ""
+        echo "Tarball plan:"
+        while IFS='|' read -r plugin_path package_name package_version tarball_path; do
+          echo "Packed: ${package_name}@${package_version} -> ${tarball_path}"
+        done < /tmp/publish-tarballs.txt
+
+    - name: Publish all tarballs
+      shell: bash
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.token }}
+      run: |
+        set -euo pipefail
+
+        while IFS='|' read -r plugin_path package_name package_version tarball_path; do
+          echo ""
+          echo "Publishing $package_name@$package_version"
+          npm publish "$tarball_path" --registry=https://npm.pkg.github.com
+        done < /tmp/publish-tarballs.txt
+
+    - name: Write published summary
+      if: ${{ success() }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        {
+          echo ""
+          echo "### Published packages"
+          echo ""
+          echo "| Package | Version |"
+          echo "|---|---|"
+          while IFS='|' read -r plugin_path package_name package_version tarball_path; do
+            echo "| \`${package_name}\` | \`${package_version}\` |"
+          done < /tmp/publish-tarballs.txt
+
+          echo ""
+          echo "### Install commands"
+          echo ""
+
+          while IFS='|' read -r plugin_path package_name package_version tarball_path; do
+            echo "\`\`\`bash"
+            echo "yarn add ${package_name}@${package_version}"
+            echo "\`\`\`"
+            echo ""
+          done < /tmp/publish-tarballs.txt
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/publish-backstage-plugins/action.yaml
+++ b/publish-backstage-plugins/action.yaml
@@ -23,12 +23,15 @@ runs:
         scope: "@bcgov"
 
     - name: Setup Yarn
+      shell: bash
       run: corepack enable && corepack prepare yarn@4.4.1 --activate
 
     - name: Install dependencies
+      shell: bash
       run: yarn install --immutable
 
     - name: Generate TypeScript declaration files
+      shell: bash
       run: yarn tsc
 
     - name: Determine release version


### PR DESCRIPTION
This action is intended to be used by all backstage plugin projects to publish their artifacts to the npm.pkg.github.com registry.

The csit-backstage-microcks-plugin project has been updated to publish using this action.  The PR will be updated to point to dev once this PR is merged.
https://github.com/bcgov/csit-backstage-microcks-plugin/pull/2